### PR TITLE
update the readme to indicate thread-safeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The **timestamp**-part of the Id should speak for itself; by default this is inc
 
 The **generator-id**-part of the Id is the part that you 'configure'; it could correspond to a host, thread, datacenter or continent: it's up to you. However, the generator-id should be unique in the system: if you have several hosts or threads generating Id's, each host or thread should have it's own generator-id. This could be based on the hostname, a config-file value or even be retrieved from an coordinating service. Remember: a generator-id should be unique within the entire system to avoid collisions!
 
+> In case of a server application, having a singleton instance of an `IdGenerator` per node with a **generator-id** which is unique within the system should be sufficient since `IdGenerator.CreateId` is thread-safe.
+
 The **sequence**-part is simply a value that is incremented each time a new Id is generated within the same tick (again, by default, a millisecond but can be anything); it is reset every time the tick changes.
 
 ## System Clock Dependency


### PR DESCRIPTION
I am essentially trying to asset my understanding with his change. When I looked at the doc, I saw this:

> The **generator-id**-part of the Id is the part that you 'configure'; it could correspond to a host, thread...

Use of "thread" confused me here. Then I looked at the code, saw that an instance of an `IdGenerator` is thread-safe: https://github.com/RobThree/IdGen/blob/ea7bcabbb566a35ed7cc08dd3265716e4abf6b67/IdGen/IdGenerator.cs#L182

@RobThree is my understanding correct here?