### PR TITLE
Fixed an off by 1 issue related to maxmium GeneratorId.

### DIFF
--- a/IdGen/IdGenerator.cs
+++ b/IdGen/IdGenerator.cs
@@ -55,11 +55,11 @@ public class IdGenerator : IIdGenerator<long>
         _generatorid = generatorId;
         Options = options ?? throw new ArgumentNullException(nameof(options));
 
-        var maxgeneratorid = 1U << Options.IdStructure.GeneratorIdBits;
+        var maxgeneratorid = (1U << Options.IdStructure.GeneratorIdBits) - 1;
 
-        if (_generatorid < 0 || _generatorid >= maxgeneratorid)
+        if (_generatorid < 0 || _generatorid > maxgeneratorid)
         {
-            throw new ArgumentOutOfRangeException(nameof(generatorId), $"GeneratorId must be between 0 and {maxgeneratorid - 1}.");
+            throw new ArgumentOutOfRangeException(nameof(generatorId), $"GeneratorId must be from 0 to {maxgeneratorid}.");
         }
 
         // Precalculate some values

--- a/IdGenTests/IdGeneratorTests.cs
+++ b/IdGenTests/IdGeneratorTests.cs
@@ -79,15 +79,35 @@ public class IdGeneratorTests
     }
 
     [TestMethod]
+    public void Constructor_DoesNotThrow_OnMaxGeneratorId()
+    {
+        var structure = new IdStructure(41, 10, 12);
+        // 1023 is the max generator id for 10 bits.
+        var maxgeneratorid = 1023;
+        new IdGenerator(maxgeneratorid, new IdGeneratorOptions(structure));
+    }
+
+    [TestMethod]
+    public void Constructor_DoesNotThrow_OnGeneratorId_0()
+    {
+        new IdGenerator(0, new IdGeneratorOptions(new IdStructure(41, 10, 12)));
+    }
+
+    [TestMethod]
     [ExpectedException(typeof(ArgumentNullException))]
     public void Constructor_Throws_OnNull_Options()
         => new IdGenerator(1024, null!);
 
-
     [TestMethod]
     [ExpectedException(typeof(ArgumentOutOfRangeException))]
-    public void Constructor_Throws_OnInvalidGeneratorId_Positive()
-        => new IdGenerator(1024, new IdGeneratorOptions(new IdStructure(41, 10, 12)));
+    public void Constructor_Throws_OnInvalidGeneratorId_Positive_MaxPlusOne()
+    {
+        var structure = new IdStructure(41, 10, 12);
+        // 1023 is the max generator id for 10 bits.
+        var maxgeneratorid = 1023;
+        int maxPlusOne = maxgeneratorid + 1;
+        new IdGenerator(maxPlusOne, new IdGeneratorOptions(structure));
+    }
 
     [TestMethod]
     [ExpectedException(typeof(ArgumentOutOfRangeException))]


### PR DESCRIPTION
Max generator id was being calculated as 1 higher than the actual max. This has been corrected and the message in the exception thrown when the given generator id is invalid has been appropriately re-worded to include 0 and `maxgeneratorid`.